### PR TITLE
Character Legend alignment

### DIFF
--- a/locales/v2.yml
+++ b/locales/v2.yml
@@ -695,4 +695,17 @@ Fonts:
   ru: Помощь
   vi: Trợ giúp
   zh: 帮助
+Trial:
+  de: Probe
+  en: Trial
+  es: Prueba
+  fr: Essai
+  it: Prova
+  ja: お試し
+  nl: Probeer
+  pl: Próba
+  pt: Teste
+  ru: Пробный
+  vi: Dùng thử 
+  zh: 试用
 _version: 2

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -74,7 +74,7 @@ fn default_font_sizes() -> BTreeMap<egui::TextStyle, FontId> {
 }
 
 fn default_legend_text_style() -> egui::TextStyle {
-    egui::TextStyle::Body
+    egui::TextStyle::Monospace
 }
 
 fn default_pie_chart_opacity() -> f32 {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,9 +1,19 @@
 pub fn format_damage(value: f64) -> String {
-    if value >= 1_000_000.0 {
+        if value >= 100_000_000_000.0 {
+        // 100.0G-Inf, Greater than 999.9G will cause the legend misaligned
+        let g = value / 1_000_000_000.0;
+        format!("{g:.1}G", g=g)
+    } else if value >= 1_000_000_000.0 {
+        // 1000M-99999M
         let m = value / 1_000_000.0;
-        format!("{:.1}M", m)
+        format!("{m:.0}M", m=m)
+    } else if value >= 1_000_000.0 {
+        // 1.0M-999.9M
+        let m = value / 1_000_000.0;
+        format!("{m:.1}M", m=m)
     } else if value >= 1_000.0 {
-        format!("{}K", (value / 1_000.0).floor())
+        let k = value / 1_000.0;
+        format!("{}K", k.floor())
     } else {
         format!("{}", value.floor())
     }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -88,11 +88,15 @@ impl App {
                 };
 
                 ui.label(format!(
-                    "{}: {:.1}% | {} DMG | {} DPAV",
-                    avatar.name,
-                    percentage,
-                    helpers::format_damage(dmg),
-                    helpers::format_damage(dpav)
+                    "{damage:>6} |{percentage:>5.1}% |{dpav:>6}/AV |@{name}",
+                    name = if avatar.name.is_empty() {
+                        format!("{} {}", t!("Trial"), i + 1)
+                    } else {
+                        avatar.name.clone()
+                    },
+                    damage = helpers::format_damage(dmg),
+                    percentage = percentage,
+                    dpav = helpers::format_damage(dpav)
                 ));
             });
         }


### PR DESCRIPTION
1. Format the items in Character Legend to align them. However, since I use Chinese, I can't handle the mixed layout of half-width characters and full-width characters, so I can only put the character names at the end.
2. The format_damage in helper.rs has been modified to enable the function to format numbers to 999.9G
3. When using Trial/Support Character in battle, the legend is displayed as empty. Now it is "Trial".

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/f0ca0bd2-ce64-4ca1-8c75-5459c9df920f" />
